### PR TITLE
Added option to increase heading level of transcluded files

### DIFF
--- a/src/BakeModal.ts
+++ b/src/BakeModal.ts
@@ -83,6 +83,18 @@ export class BakeModal extends Modal {
         })
       );
 
+    new Setting(contentEl)
+      .setName("Increment heading levels")
+      .setDesc(
+          "Increase the heading levels of transcluded markdown files."
+      )
+      .addToggle((toggle) => 
+        toggle.setValue(settings.incrementHeadingLevels).onChange((value) => {
+          settings.incrementHeadingLevels = value;
+          plugin.saveSettings();
+        })
+      );
+
     new Setting(contentEl).setName('Output file name').then((setting) => {
       new Setting(contentEl).then((setting) => {
         setting.addButton((btn) =>

--- a/src/bake.ts
+++ b/src/bake.ts
@@ -13,6 +13,7 @@ import {
   extractSubpath,
   sanitizeBakedContent,
   stripFirstBullet,
+  incrementHeadings,
 } from './util';
 
 const lineStartRE = /(?:^|\n) *$/;
@@ -102,9 +103,9 @@ export async function bake(
     }
 
     // Recurse and bake the linked file...
-    const baked = sanitizeBakedContent(
+    const baked = incrementHeadings(sanitizeBakedContent(
       await bake(app, linkedFile, subpath, newAncestors, settings)
-    );
+    ), settings.incrementHeadingLevels);
     replaceTarget(
       listMatch ? applyIndent(stripFirstBullet(baked), listMatch[1]) : baked
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,5 +48,24 @@ export default class EasyBake extends Plugin {
         new BakeModal(this, file).open();
       },
     });
+
+    this.addCommand({
+      id: 'bake-file:saved-settings',
+      name: 'Bake current file using saved settings',
+      checkCallback: (checking) => {
+        // Current file
+        const file = this.activeMarkdownFile;
+        if (checking || !file) return !!file;
+        // Output file
+        let outputName = file.basename + '.baked';
+        let outputFolder = file.parent?.path || '';
+        if (outputFolder) outputFolder += '/';
+        // Bake
+        const inputPath = file.path;
+        const outputPath = outputFolder + outputName + '.md';
+        this.api.bakeAndOpen(inputPath, outputPath, this.settings)
+      },
+    });
+    
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ export interface BakeSettings {
   bakeEmbeds: boolean;
   bakeInList: boolean;
   convertFileLinks: boolean;
+  incrementHeadingLevels: boolean;
 }
 
 const DEFAULT_SETTINGS: BakeSettings = {
@@ -15,6 +16,7 @@ const DEFAULT_SETTINGS: BakeSettings = {
   bakeEmbeds: true,
   bakeInList: true,
   convertFileLinks: true,
+  incrementHeadingLevels: false,
 };
 
 export default class EasyBake extends Plugin {

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,6 +47,11 @@ export function stripFrontmatter(text: string) {
   return text.replace(/^---[\s\S]+?\r?\n---(?:\r?\n\s*|$)/, '');
 }
 
+export function incrementHeadings(text: string, incrementHeadings: boolean) {
+  if (!text || !incrementHeadings) return text;
+  return text.replace(/^(#+)(\s)/gm, (match, hashes, space) => '#'.repeat(hashes.length + 1) + space);
+}
+
 export function sanitizeBakedContent(text: string) {
   return stripBlockId(stripFrontmatter(text));
 }


### PR DESCRIPTION
Sometimes if you have a note.md

```md
# Abstract
...
# Introduction
...
# Chapter 1
[[chapter1.md]]
```

and chapter1.md

```md
# Abstract
...
# Introduction
...
# Methods
...
```
You want to include the chapter increasing the heading levels by one, so note.baked.md

```md
# Abstract
...
# Introduction
...
# Chapter 1
## Abstract
...
## Introduction
...
## Methods
...
```

This pull request accomplishes that, and adds a command `bake-file:saved-settings` using the new API.

Nevertheless, I am not sure if this is the best place to call the new `incrementHeadings` function (bake.ts):

```ts
    // Recurse and bake the linked file...
    const baked = incrementHeadings(sanitizeBakedContent(
      await bake(app, linkedFile, subpath, newAncestors, settings)
    ), settings.incrementHeadingLevels);
```

Related to #8.